### PR TITLE
Ignore when px value is wrapped in a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const hasForbiddenPX = (node, options) => {
 
   parsed.walk(node => {
     // if node is `url(xxx)`, prevent the traversal
-    if (node.type === 'function' && node.value === 'url') {
+    if (node.type === 'function') {
       return false
     }
 


### PR DESCRIPTION
Thanks for the plugin, it works nicely! 

In many projects I use `rem()` or `rem-calc()` SASS functions, to have the values given in Zeplin or Photoshop converted automatically into rems without thinking much. (Those functions may also change the way they work depending on the environment, for example, on local they may output pixels without conversion, for easier debugging in browser — while outputting real rems on staging/production).

Currently the plugin doesn't account for the SASS/CSS functions except for the URL. I've just removed the conditional for `url` so that it would skip the property if it's wrapped in any function.