### PR TITLE
Deprecate `context.fix` in favour of the `fix` callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ export const meta = {
 export const messages = stylelint.utils.ruleMessages(ruleName, {
   rem(remSize) {
     if (remSize) {
-      return `Use rem instead of px. 'px' values have been converted to 'rem'.`;
+      return `Use rem instead of px.`;
     }
     return `Use rem instead of px. To enable automatic conversion, set the 'remSize' option in the plugin settings.`;
   },
@@ -99,41 +99,49 @@ function processValue(value, prop, options) {
   const hasPx = processValueNodes(parsed.nodes, prop, options);
 
   return {
-    newValue: valueParser.stringify(parsed.nodes),
     hasPx,
+    getFixedValue: () => {
+        return valueParser.stringify(parsed.nodes);
+    }
   };
 }
 
 function processDeclaration(declaration, options) {
   if (propInIgnoreList(declaration.prop, options.ignore)) {
-    return;
+    return { hasPx: false, fixCallback: null };
   }
 
-  const { newValue, hasPx } = processValue(
+  const { hasPx, getFixedValue } = processValue(
     declaration.value,
     declaration.prop,
     options,
   );
 
-  declaration.value = newValue;
+  const fixCallback = () => {
+    declaration.value = getFixedValue();
+  };
 
-  return hasPx;
+  return { hasPx, fixCallback };
 }
 
 function processAtRule(atRule, options) {
   if (atRule.type === "atrule" && atRule.name === "media") {
-    return;
+    return { hasPx: false, fixCallback: null };
   }
 
-  const { newValue, hasPx } = processValue(atRule.params, null, options);
+  const { hasPx, getFixedValue } = processValue(atRule.params, null, options);
 
-  atRule.params = newValue;
-  atRule.value = newValue;
+  const fixCallback = () => {
+    const newValue = getFixedValue();
 
-  return hasPx;
+    atRule.params = newValue;
+    atRule.value = newValue;
+  }
+
+  return { hasPx, fixCallback };
 }
 
-function ruleFunction(primaryOption, secondaryOptionObject, context) {
+function ruleFunction(primaryOption, secondaryOptionObject) {
   primaryOption = primaryOption || "";
 
   return (root, result) => {
@@ -148,26 +156,29 @@ function ruleFunction(primaryOption, secondaryOptionObject, context) {
     secondaryOptionObject = { ignore, remSize, ignoreFunctions };
 
     root.walkDecls((declaration) => {
-      if (
-        processDeclaration(declaration, secondaryOptionObject) &&
-        !context.fix
-      ) {
+      const { hasPx, fixCallback } = processDeclaration(declaration, secondaryOptionObject);
+
+      if (hasPx) {
         stylelint.utils.report({
           ruleName: ruleName,
           result: result,
           node: declaration,
           message: messages.rem(secondaryOptionObject.remSize),
+          fix: fixCallback,
         });
       }
     });
 
     root.walkAtRules((atRule) => {
-      if (processAtRule(atRule, secondaryOptionObject) && !context.fix) {
+      const { hasPx, fixCallback } = processAtRule(atRule, secondaryOptionObject);
+
+      if (hasPx) {
         stylelint.utils.report({
           ruleName: ruleName,
           result: result,
           node: atRule,
           message: messages.rem(secondaryOptionObject.remSize),
+          fix: fixCallback,
         });
       }
     });


### PR DESCRIPTION
This fixes the deprecation introduced in https://github.com/stylelint/stylelint/pull/7895

```
(node:10811) [stylelint:005] DeprecationWarning: `context.fix` is being deprecated.
Please pass a `fix` callback to the `report` utility of "meowtec/no-px" instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```
